### PR TITLE
Fixed a bug in Nbt#fromFile where one FileInputStream was not closed correctly and remained open

### DIFF
--- a/src/main/java/dev/dewy/nbt/Nbt.java
+++ b/src/main/java/dev/dewy/nbt/Nbt.java
@@ -194,7 +194,8 @@ public class Nbt {
         @Cleanup BufferedInputStream bis = new BufferedInputStream(new FileInputStream(file));
         @Cleanup DataInputStream in = null;
 
-        switch (CompressionType.getCompression(new FileInputStream(file))) {
+        @Cleanup FileInputStream fis = new FileInputStream(file);
+        switch (CompressionType.getCompression(fis)) {
             case NONE:
                 in = new DataInputStream(bis);
                 break;


### PR DESCRIPTION
Added @Cleanup to the mentioned FileInputStream so that it gets closed correctly